### PR TITLE
Adds Support for Project Files in Settings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,12 @@
                             "template.uvproj",
                             "template.uvprojx"
                         ]
+                    },
+                    "KeilAssistant.Project.FileLocationList": {
+                        "type": "array",
+                        "scope": "resource",
+                        "markdownDescription": "uVision project file locations",
+                        "default": []
                     }
                 }
             }
@@ -289,6 +295,8 @@
         "webpack-cli": "^3.3.11"
     },
     "dependencies": {
+        "@types/vscode": "^1.38.0",
+        "vscode-variables": "^0.1.3",
         "xml2js": "^0.4.23"
     }
 }

--- a/src/ResourceManager.ts
+++ b/src/ResourceManager.ts
@@ -71,6 +71,10 @@ export class ResourceManager {
         return this.getAppConfig().get<string[]>('Project.ExcludeList') || [];
     }
 
+    getProjectFileLocationList(): string[] {
+        return this.getAppConfig().get<string[]>('Project.FileLocationList') || [];
+    }
+
     getIconByName(name: string): string | undefined {
         return this.iconMap.get(name);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import * as event from 'events';
 import * as fs from 'fs';
 import * as node_path from 'path';
 import * as child_process from 'child_process';
+import * as vscodeVariables from 'vscode-variables';
 
 import { File } from '../lib/node-utility/File';
 import { ResourceManager } from './ResourceManager';
@@ -1160,11 +1161,11 @@ class ProjectExplorer implements vscode.TreeDataProvider<IView> {
             const workspace = new File(wsFilePath);
             if (workspace.IsDir()) {
                 const excludeList = ResourceManager.getInstance().getProjectExcludeList();
-                const uvList = workspace.GetList([/\.uvproj[x]?$/i], File.EMPTY_FILTER)
+                const uvList = workspace.GetList([/\.uvproj[x]?$/i], File.EMPTY_FILTER).concat(ResourceManager.getInstance().getProjectFileLocationList())
                     .filter((file) => { return !excludeList.includes(file.name); });
                 for (const uvFile of uvList) {
                     try {
-                        await this.openProject(uvFile.path);
+                        await this.openProject(vscodeVariables(uvFile));
                     } catch (error) {
                         vscode.window.showErrorMessage(`open project: '${uvFile.name}' failed !, msg: ${(<Error>error).message}`);
                     }


### PR DESCRIPTION
* Adds a Setting to add a possible .uvprojx file to be loaded
* Adds the vscode-variables node module to support ${workspaceFolder} settings.

It would be nice if you could commit the .gitmodules file to load the submodules, so a fellow developer could test or package the extension.